### PR TITLE
feat: add Signal support for RTT-based activity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">Device Activity Tracker</h1>
-<p align="center">WhatsApp Activity Tracker via RTT Analysis</p>
+<p align="center">WhatsApp & Signal Activity Tracker via RTT Analysis</p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/Node.js-20+-339933?style=flat&logo=node.js&logoColor=white" alt="Node.js"/>
@@ -106,15 +106,24 @@ In the web interface, you can switch between probe methods using the dropdown in
 
 - **Not Connecting to WhatsApp**: Delete the `auth_info_baileys/` folder and re-scan the QR code.
 
+- **Enabling Signal Support**: Signal support is optional and auto-detected. To enable it, run the signal-cli-rest-api Docker container:
+  ```bash
+  docker run -d --name signal-api -p 8080:8080 \
+    -v $HOME/.local/share/signal-api:/home/.local/share/signal-cli \
+    -e 'MODE=json-rpc' bbernhard/signal-cli-rest-api
+  ```
+  Then link your Signal account via http://localhost:8080/v1/qrcodelink?device_name=activity-tracker
+
 ## Project Structure
 
 ```
 device-activity-tracker/
 ├── src/
-│   ├── tracker.ts      # Core RTT analysis logic
-│   ├── server.ts       # Backend API server
-│   └── index.ts        # CLI interface
-├── client/             # React web interface
+│   ├── tracker.ts         # WhatsApp RTT analysis logic
+│   ├── signal-tracker.ts  # Signal RTT analysis logic
+│   ├── server.ts          # Backend API server (both platforms)
+│   └── index.ts           # CLI interface
+├── client/                # React web interface
 └── package.json
 ```
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,11 +3,30 @@ import { io, Socket } from 'socket.io-client';
 import { Login } from './components/Login';
 import { Dashboard } from './components/Dashboard';
 
-export const socket: Socket = io('http://localhost:3001');
+// Create socket with autoConnect disabled so we can add listeners before connecting
+export const socket: Socket = io('http://localhost:3001', { autoConnect: false });
+
+export type Platform = 'whatsapp' | 'signal';
+
+export interface ConnectionState {
+    whatsapp: boolean;
+    signal: boolean;
+    signalNumber: string | null;
+    signalApiAvailable: boolean;
+    signalQrImage: string | null;
+}
 
 function App() {
     const [isConnected, setIsConnected] = useState(socket.connected);
-    const [isWhatsAppReady, setIsWhatsAppReady] = useState(false);
+    const [connectionState, setConnectionState] = useState<ConnectionState>({
+        whatsapp: false,
+        signal: false,
+        signalNumber: null,
+        signalApiAvailable: false,
+        signalQrImage: null
+    });
+
+    const isAnyPlatformReady = connectionState.whatsapp || connectionState.signal;
 
     useEffect(() => {
         function onConnect() {
@@ -16,21 +35,65 @@ function App() {
 
         function onDisconnect() {
             setIsConnected(false);
-            setIsWhatsAppReady(false);
+            setConnectionState({
+                whatsapp: false,
+                signal: false,
+                signalNumber: null,
+                signalApiAvailable: false,
+                signalQrImage: null
+            });
         }
 
-        function onConnectionOpen() {
-            setIsWhatsAppReady(true);
+        function onWhatsAppConnectionOpen() {
+            setConnectionState(prev => ({ ...prev, whatsapp: true }));
+        }
+
+        function onSignalConnectionOpen(data: { number: string }) {
+            setConnectionState(prev => ({
+                ...prev,
+                signal: true,
+                signalNumber: data.number
+            }));
+        }
+
+        function onSignalDisconnected() {
+            setConnectionState(prev => ({
+                ...prev,
+                signal: false,
+                signalNumber: null
+            }));
+        }
+
+        function onSignalApiStatus(data: { available: boolean }) {
+            setConnectionState(prev => ({ ...prev, signalApiAvailable: data.available }));
+        }
+
+        function onSignalQrImage(url: string) {
+            console.log('[SIGNAL] Received QR image URL:', url);
+            setConnectionState(prev => ({ ...prev, signalQrImage: url }));
         }
 
         socket.on('connect', onConnect);
         socket.on('disconnect', onDisconnect);
-        socket.on('connection-open', onConnectionOpen);
+        socket.on('connection-open', onWhatsAppConnectionOpen);
+        socket.on('signal-connection-open', onSignalConnectionOpen);
+        socket.on('signal-disconnected', onSignalDisconnected);
+        socket.on('signal-api-status', onSignalApiStatus);
+        socket.on('signal-qr-image', onSignalQrImage);
+
+        // Now connect after listeners are set up
+        if (!socket.connected) {
+            socket.connect();
+        }
 
         return () => {
             socket.off('connect', onConnect);
             socket.off('disconnect', onDisconnect);
-            socket.off('connection-open', onConnectionOpen);
+            socket.off('connection-open', onWhatsAppConnectionOpen);
+            socket.off('signal-connection-open', onSignalConnectionOpen);
+            socket.off('signal-disconnected', onSignalDisconnected);
+            socket.off('signal-api-status', onSignalApiStatus);
+            socket.off('signal-qr-image', onSignalQrImage);
         };
     }, []);
 
@@ -38,25 +101,28 @@ function App() {
         <div className="min-h-screen bg-gray-100 p-8">
             <div className="max-w-6xl mx-auto">
                 <header className="mb-8 flex justify-between items-center">
-                    <h1 className="text-3xl font-bold text-gray-900">WhatsApp Tracker</h1>
+                    <h1 className="text-3xl font-bold text-gray-900">Activity Tracker</h1>
                     <div className="flex items-center gap-2">
                         <div className={`w-3 h-3 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
                         <span className="text-sm text-gray-600">{isConnected ? 'Server Connected' : 'Disconnected'}</span>
                         {isConnected && (
                             <>
                                 <div className="w-px h-4 bg-gray-300 mx-2" />
-                                <div className={`w-3 h-3 rounded-full ${isWhatsAppReady ? 'bg-green-500' : 'bg-yellow-500'}`} />
-                                <span className="text-sm text-gray-600">{isWhatsAppReady ? 'WhatsApp Ready' : 'Waiting for WhatsApp'}</span>
+                                <div className={`w-3 h-3 rounded-full ${connectionState.whatsapp ? 'bg-green-500' : 'bg-yellow-500'}`} />
+                                <span className="text-sm text-gray-600">WhatsApp</span>
+                                <div className="w-px h-4 bg-gray-300 mx-2" />
+                                <div className={`w-3 h-3 rounded-full ${connectionState.signal ? 'bg-blue-500' : 'bg-yellow-500'}`} />
+                                <span className="text-sm text-gray-600">Signal</span>
                             </>
                         )}
                     </div>
                 </header>
 
                 <main>
-                    {!isWhatsAppReady ? (
-                        <Login />
+                    {!isAnyPlatformReady ? (
+                        <Login connectionState={connectionState} />
                     ) : (
-                        <Dashboard />
+                        <Dashboard connectionState={connectionState} />
                     )}
                 </main>
             </div>

--- a/client/src/components/ContactCard.tsx
+++ b/client/src/components/ContactCard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import { Square, Activity, Wifi, Smartphone, Monitor } from 'lucide-react';
+import { Square, Activity, Wifi, Smartphone, Monitor, MessageCircle } from 'lucide-react';
 import clsx from 'clsx';
+
+type Platform = 'whatsapp' | 'signal';
 
 interface TrackerData {
     rtt: number;
@@ -29,6 +31,7 @@ interface ContactCardProps {
     profilePic: string | null;
     onRemove: () => void;
     privacyMode?: boolean;
+    platform?: Platform;
 }
 
 export function ContactCard({
@@ -40,7 +43,8 @@ export function ContactCard({
     presence,
     profilePic,
     onRemove,
-    privacyMode = false
+    privacyMode = false,
+    platform = 'whatsapp'
 }: ContactCardProps) {
     const lastData = data[data.length - 1];
     const currentStatus = devices.length > 0
@@ -56,7 +60,16 @@ export function ContactCard({
         <div className="bg-gradient-to-br from-white to-gray-50 rounded-xl shadow-lg border border-gray-200 overflow-hidden">
             {/* Header with Stop Button */}
             <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-gray-900">{blurredNumber}</h3>
+                <div className="flex items-center gap-3">
+                    <span className={clsx(
+                        "px-2 py-1 rounded text-xs font-medium flex items-center gap-1",
+                        platform === 'whatsapp' ? "bg-green-100 text-green-700" : "bg-blue-100 text-blue-700"
+                    )}>
+                        <MessageCircle size={12} />
+                        {platform === 'whatsapp' ? 'WhatsApp' : 'Signal'}
+                    </span>
+                    <h3 className="text-lg font-semibold text-gray-900">{blurredNumber}</h3>
+                </div>
                 <button
                     onClick={onRemove}
                     className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 flex items-center gap-2 font-medium transition-colors text-sm"

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -1,37 +1,102 @@
 import React, { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { socket } from '../App';
+import { socket, ConnectionState } from '../App';
+import { CheckCircle } from 'lucide-react';
 
-export function Login() {
-    const [qrCode, setQrCode] = useState<string | null>(null);
+interface LoginProps {
+    connectionState: ConnectionState;
+}
+
+export function Login({ connectionState }: LoginProps) {
+    const [whatsappQr, setWhatsappQr] = useState<string | null>(null);
 
     useEffect(() => {
-        function onQr(qr: string) {
-            setQrCode(qr);
+        function onWhatsAppQr(qr: string) {
+            setWhatsappQr(qr);
         }
 
-        socket.on('qr', onQr);
+        socket.on('qr', onWhatsAppQr);
 
         return () => {
-            socket.off('qr', onQr);
+            socket.off('qr', onWhatsAppQr);
         };
     }, []);
 
     return (
-        <div className="flex flex-col items-center justify-center bg-white p-8 rounded-xl shadow-sm border border-gray-200">
-            <h2 className="text-2xl font-semibold mb-6">Connect WhatsApp</h2>
-            <div className="bg-gray-50 p-4 rounded-lg mb-6">
-                {qrCode ? (
-                    <QRCodeSVG value={qrCode} size={256} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* WhatsApp Connection */}
+            <div className="flex flex-col items-center justify-center bg-white p-8 rounded-xl shadow-sm border border-gray-200">
+                <div className="flex items-center gap-2 mb-6">
+                    <h2 className="text-2xl font-semibold">Connect WhatsApp</h2>
+                    {connectionState.whatsapp && (
+                        <CheckCircle className="text-green-500" size={24} />
+                    )}
+                </div>
+                {connectionState.whatsapp ? (
+                    <div className="w-64 h-64 flex flex-col items-center justify-center text-green-600 bg-green-50 rounded-lg">
+                        <CheckCircle size={64} className="mb-4" />
+                        <span className="text-lg font-medium">Connected!</span>
+                    </div>
                 ) : (
-                    <div className="w-64 h-64 flex items-center justify-center text-gray-400">
-                        Waiting for QR Code...
+                    <>
+                        <div className="bg-gray-50 p-4 rounded-lg mb-6">
+                            {whatsappQr ? (
+                                <QRCodeSVG value={whatsappQr} size={256} />
+                            ) : (
+                                <div className="w-64 h-64 flex items-center justify-center text-gray-400">
+                                    Waiting for QR Code...
+                                </div>
+                            )}
+                        </div>
+                        <p className="text-gray-600 text-center max-w-md">
+                            Open WhatsApp on your phone, go to Settings {'>'} Linked Devices, and scan the QR code to connect.
+                        </p>
+                    </>
+                )}
+            </div>
+
+            {/* Signal Connection */}
+            <div className="flex flex-col items-center justify-center bg-white p-8 rounded-xl shadow-sm border border-gray-200">
+                <div className="flex items-center gap-2 mb-6">
+                    <h2 className="text-2xl font-semibold">Connect Signal</h2>
+                    {connectionState.signal && (
+                        <CheckCircle className="text-blue-500" size={24} />
+                    )}
+                </div>
+                {connectionState.signal ? (
+                    <div className="w-64 h-64 flex flex-col items-center justify-center text-blue-600 bg-blue-50 rounded-lg">
+                        <CheckCircle size={64} className="mb-4" />
+                        <span className="text-lg font-medium">Connected!</span>
+                        <span className="text-sm text-blue-500 mt-2">{connectionState.signalNumber}</span>
+                    </div>
+                ) : connectionState.signalApiAvailable ? (
+                    <>
+                        <div className="bg-gray-50 p-4 rounded-lg mb-6">
+                            {connectionState.signalQrImage ? (
+                                <img
+                                    src={connectionState.signalQrImage}
+                                    alt="Signal QR Code"
+                                    width={256}
+                                    height={256}
+                                    className="bg-white"
+                                />
+                            ) : (
+                                <div className="w-64 h-64 flex items-center justify-center text-gray-400">
+                                    Waiting for QR Code...
+                                </div>
+                            )}
+                        </div>
+                        <p className="text-gray-600 text-center max-w-md">
+                            Open Signal on your phone, go to Settings {'>'} Linked Devices, and scan the QR code to connect.
+                        </p>
+                    </>
+                ) : (
+                    <div className="w-64 h-64 flex flex-col items-center justify-center text-gray-400 bg-gray-50 rounded-lg">
+                        <p className="text-center px-4">Signal API not available</p>
+                        <p className="text-xs text-center px-4 mt-2">Run the signal-cli-rest-api Docker container to enable</p>
                     </div>
                 )}
             </div>
-            <p className="text-gray-600 text-center max-w-md">
-                Open WhatsApp on your phone, go to Settings {'>'} Linked Devices, and scan the QR code to connect.
-            </p>
         </div>
     );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "device-activity-tracker",
   "version": "1.0.0",
+  "type": "module",
   "description": "A proof-of-concept tool demonstrating privacy vulnerabilities in messaging apps through RTT-based activity analysis",
   "main": "dist/index.js",
   "keywords": [
@@ -26,8 +27,9 @@
   "homepage": "https://github.com/gommzystudio/device-activity-tracker#readme",
   "scripts": {
     "build": "tsc",
-    "start": "npx ts-node src/index.ts",
-    "start:server": "npx ts-node src/server.ts",
+    "start": "npx tsx src/index.ts",
+    "start:server": "npm run start:signal-api && npx tsx src/server.ts",
+    "start:signal-api": "docker start signal-api 2>/dev/null || docker run -d --name signal-api -p 8080:8080 -v $HOME/.local/share/signal-api:/home/.local/share/signal-cli -e MODE=json-rpc bbernhard/signal-cli-rest-api || true",
     "start:client": "cd client && npm start",
     "dev": "npm run start:server",
     "postinstall": "cd client && npm install"
@@ -39,13 +41,16 @@
     "pdf-parse": "^1.1.1",
     "pino": "^10.1.0",
     "qrcode-terminal": "^0.12.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/qrcode-terminal": "^0.12.2",
+    "@types/ws": "^8.18.1",
     "tailwindcss": "^3.4.18",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.2"
   },
   "private": true

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import makeWASocket, { DisconnectReason, useMultiFileAuthState } from '@whiskeys
 import { pino } from 'pino';
 import { Boom } from '@hapi/boom';
 import * as qrcode from 'qrcode-terminal';
-import { WhatsAppTracker } from './tracker';
+import { WhatsAppTracker } from './tracker.js';
 import * as readline from 'readline';
 
 if (debugMode) {

--- a/src/signal-tracker.ts
+++ b/src/signal-tracker.ts
@@ -1,0 +1,553 @@
+/**
+ * Signal Activity Tracker
+ *
+ * Monitors Signal user activity using RTT-based analysis via signal-cli-rest-api.
+ * Uses WebSocket connection in json-rpc mode to receive delivery receipts.
+ */
+
+import WebSocket from 'ws';
+
+export type ProbeMethod = 'reaction' | 'message';
+
+interface DeviceMetrics {
+    rttHistory: number[];
+    recentRtts: number[];
+    state: string;
+    lastRtt: number;
+    lastUpdate: number;
+}
+
+// JSON-RPC message format for receipts
+interface JsonRpcMessage {
+    jsonrpc: string;
+    method?: string;
+    params?: {
+        envelope?: {
+            source?: string;
+            sourceNumber?: string;
+            timestamp?: number;
+            receiptMessage?: {
+                when: number;
+                isDelivery: boolean;
+                isRead: boolean;
+                timestamps: number[];
+            };
+        };
+    };
+}
+
+class TrackerLogger {
+    private isDebugMode: boolean;
+
+    constructor(debugMode: boolean = false) {
+        this.isDebugMode = debugMode;
+    }
+
+    setDebugMode(enabled: boolean) {
+        this.isDebugMode = enabled;
+    }
+
+    debug(...args: any[]) {
+        if (this.isDebugMode) {
+            console.log('[SIGNAL]', ...args);
+        }
+    }
+
+    info(...args: any[]) {
+        console.log('[SIGNAL]', ...args);
+    }
+}
+
+const logger = new TrackerLogger(true);
+
+export class SignalTracker {
+    private apiUrl: string;
+    private senderNumber: string;
+    private targetNumber: string;
+    private isTracking: boolean = false;
+    private deviceMetrics: Map<string, DeviceMetrics> = new Map();
+    private globalRttHistory: number[] = [];
+    private probeMethod: ProbeMethod = 'reaction';
+    private ws: WebSocket | null = null;
+    private reconnectTimeout: NodeJS.Timeout | null = null;
+    public onUpdate?: (data: any) => void;
+
+    // Serialized probe tracking (per Codex recommendation)
+    // Only ONE probe in flight at a time - correlate by order, not timestamp
+    private pendingProbeStartTime: number | null = null;
+    private pendingProbeTimeout: NodeJS.Timeout | null = null;
+    private probeResolve: (() => void) | null = null;
+
+    constructor(
+        apiUrl: string,
+        senderNumber: string,
+        targetNumber: string,
+        debugMode: boolean = false
+    ) {
+        this.apiUrl = apiUrl.replace(/\/$/, '');
+        this.senderNumber = senderNumber;
+        this.targetNumber = targetNumber;
+        logger.setDebugMode(debugMode);
+    }
+
+    public setProbeMethod(method: ProbeMethod) {
+        this.probeMethod = method;
+        logger.info(`Probe method changed to: ${method}`);
+    }
+
+    public getProbeMethod(): ProbeMethod {
+        return this.probeMethod;
+    }
+
+    /**
+     * Start tracking the target user's activity
+     */
+    public async startTracking() {
+        if (this.isTracking) return;
+        this.isTracking = true;
+        logger.info(`Tracking started for ${this.targetNumber}`);
+        logger.info(`Probe method: ${this.probeMethod}`);
+
+        if (this.onUpdate) {
+            this.onUpdate({
+                devices: [],
+                deviceCount: 1,
+                presence: null,
+                median: 0,
+                threshold: 0
+            });
+        }
+
+        // Connect WebSocket for receiving receipts
+        this.connectWebSocket();
+
+        // Start the probe loop
+        this.probeLoop();
+    }
+
+    /**
+     * Connect to signal-cli-rest-api WebSocket for receiving messages
+     */
+    private connectWebSocket() {
+        if (!this.isTracking) return;
+
+        const wsUrl = this.apiUrl.replace('http', 'ws') + '/v1/receive/' + encodeURIComponent(this.senderNumber);
+        logger.debug(`Connecting WebSocket to ${wsUrl}`);
+
+        try {
+            this.ws = new WebSocket(wsUrl);
+
+            this.ws.on('open', () => {
+                logger.info('WebSocket connected for receiving receipts');
+            });
+
+            this.ws.on('message', (data: WebSocket.Data) => {
+                try {
+                    const raw = data.toString();
+                    logger.debug('WebSocket raw message:', raw.substring(0, 500));
+                    const message = JSON.parse(raw) as JsonRpcMessage;
+                    this.processJsonRpcMessage(message);
+                } catch (err) {
+                    logger.debug('Error parsing WebSocket message:', err);
+                }
+            });
+
+            this.ws.on('close', () => {
+                logger.debug('WebSocket closed');
+                this.scheduleReconnect();
+            });
+
+            this.ws.on('error', (err) => {
+                logger.debug('WebSocket error:', err);
+                this.scheduleReconnect();
+            });
+        } catch (err) {
+            logger.debug('Error creating WebSocket:', err);
+            this.scheduleReconnect();
+        }
+    }
+
+    private scheduleReconnect() {
+        if (!this.isTracking) return;
+        if (this.reconnectTimeout) return;
+
+        this.reconnectTimeout = setTimeout(() => {
+            this.reconnectTimeout = null;
+            if (this.isTracking) {
+                logger.debug('Reconnecting WebSocket...');
+                this.connectWebSocket();
+            }
+        }, 5000);
+    }
+
+    private processJsonRpcMessage(message: any) {
+        // Handle both JSON-RPC format and direct envelope format
+        let envelope = message.params?.envelope || message.envelope;
+
+        if (!envelope) {
+            logger.debug('No envelope in message');
+            return;
+        }
+
+        // Check if this is a delivery receipt from our target
+        const sourceNumber = envelope.sourceNumber || envelope.source;
+
+        if (envelope.receiptMessage?.isDelivery) {
+            logger.debug(`Delivery receipt from ${sourceNumber}`);
+
+            // Serialized probe approach: if we have a pending probe, ANY delivery receipt
+            // from the target is for that probe (since we only send one at a time)
+            if (this.pendingProbeStartTime !== null && sourceNumber === this.targetNumber) {
+                const receiptTime = Date.now();
+                const rtt = receiptTime - this.pendingProbeStartTime;
+
+                logger.info(`Delivery receipt matched! RTT: ${rtt}ms`);
+
+                // Clear the timeout
+                if (this.pendingProbeTimeout) {
+                    clearTimeout(this.pendingProbeTimeout);
+                    this.pendingProbeTimeout = null;
+                }
+
+                // Record the measurement
+                this.addMeasurementForDevice(this.targetNumber, rtt);
+
+                // Clear pending probe and signal completion
+                this.pendingProbeStartTime = null;
+                if (this.probeResolve) {
+                    this.probeResolve();
+                    this.probeResolve = null;
+                }
+            }
+        }
+    }
+
+    private async probeLoop() {
+        while (this.isTracking) {
+            try {
+                // Serialized probing: wait for previous probe to complete before sending next
+                await this.sendSerializedProbe();
+            } catch (err) {
+                logger.debug('Error sending probe:', err);
+            }
+            // Small delay between probes
+            const delay = Math.floor(Math.random() * 1000) + 1000;
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
+    }
+
+    /**
+     * Send a probe and wait for receipt or timeout before returning
+     * This ensures only ONE probe is in flight at a time (serialization)
+     */
+    private async sendSerializedProbe(): Promise<void> {
+        return new Promise<void>(async (resolve) => {
+            // Store resolve function so receipt handler can signal completion
+            this.probeResolve = resolve;
+
+            // Record probe start time
+            this.pendingProbeStartTime = Date.now();
+
+            // Send the probe
+            await this.sendProbe();
+
+            // Set timeout - if no receipt within 15s, mark offline and continue
+            this.pendingProbeTimeout = setTimeout(() => {
+                if (this.pendingProbeStartTime !== null) {
+                    const elapsed = Date.now() - this.pendingProbeStartTime;
+                    logger.debug(`Probe timeout after ${elapsed}ms`);
+                    this.markDeviceOffline(this.targetNumber, elapsed);
+                    this.pendingProbeStartTime = null;
+                    this.pendingProbeTimeout = null;
+                    if (this.probeResolve) {
+                        this.probeResolve();
+                        this.probeResolve = null;
+                    }
+                }
+            }, 15000);
+        });
+    }
+
+    private async sendProbe() {
+        if (this.probeMethod === 'reaction') {
+            await this.sendReactionProbe();
+        } else {
+            await this.sendMessageProbe();
+        }
+    }
+
+    /**
+     * Send a reaction probe - sends a reaction to trigger delivery receipt
+     * Uses serialized approach: correlation is by order, not timestamp
+     */
+    private async sendReactionProbe() {
+        const timestamp = Date.now();
+        const reactions = ['👍', '❤️', '😂', '😮', '😢', '🙏'];
+        const randomReaction = reactions[Math.floor(Math.random() * reactions.length)];
+
+        try {
+            const response = await fetch(`${this.apiUrl}/v1/reactions/${encodeURIComponent(this.senderNumber)}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    reaction: randomReaction,
+                    recipient: this.targetNumber,
+                    target_author: this.targetNumber,
+                    timestamp: timestamp - 86400000 // Fake timestamp for non-existent message
+                })
+            });
+
+            if (response.ok || response.status === 204) {
+                logger.debug(`Reaction probe sent: ${randomReaction}`);
+            } else {
+                const errorText = await response.text();
+                logger.debug(`Failed to send reaction probe: ${response.status} - ${errorText}`);
+            }
+        } catch (err) {
+            logger.debug('Error sending reaction probe:', err);
+        }
+    }
+
+    /**
+     * Send a message probe - sends an invisible/minimal message
+     * Uses serialized approach: correlation is by order, not timestamp
+     */
+    private async sendMessageProbe() {
+        try {
+            const response = await fetch(`${this.apiUrl}/v2/send`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    number: this.senderNumber,
+                    recipients: [this.targetNumber],
+                    message: '\u200B' // Zero-width space (nearly invisible)
+                })
+            });
+
+            if (response.ok) {
+                logger.debug('Message probe sent');
+            } else {
+                const errorText = await response.text();
+                logger.debug(`Failed to send message probe: ${response.status} - ${errorText}`);
+            }
+        } catch (err) {
+            logger.debug('Error sending message probe:', err);
+        }
+    }
+
+    private markDeviceOffline(identifier: string, timeout: number) {
+        if (!this.deviceMetrics.has(identifier)) {
+            this.deviceMetrics.set(identifier, {
+                rttHistory: [],
+                recentRtts: [],
+                state: 'OFFLINE',
+                lastRtt: timeout,
+                lastUpdate: Date.now()
+            });
+        } else {
+            const metrics = this.deviceMetrics.get(identifier)!;
+            metrics.state = 'OFFLINE';
+            metrics.lastRtt = timeout;
+            metrics.lastUpdate = Date.now();
+        }
+
+        logger.info(`Device ${identifier} marked as OFFLINE (no receipt after ${timeout}ms)`);
+        this.sendUpdate();
+    }
+
+    private addMeasurementForDevice(identifier: string, rtt: number) {
+        if (!this.deviceMetrics.has(identifier)) {
+            this.deviceMetrics.set(identifier, {
+                rttHistory: [],
+                recentRtts: [],
+                state: 'Calibrating...',
+                lastRtt: rtt,
+                lastUpdate: Date.now()
+            });
+        }
+
+        const metrics = this.deviceMetrics.get(identifier)!;
+
+        if (rtt <= 5000) {
+            metrics.recentRtts.push(rtt);
+            if (metrics.recentRtts.length > 3) {
+                metrics.recentRtts.shift();
+            }
+
+            metrics.rttHistory.push(rtt);
+            if (metrics.rttHistory.length > 2000) {
+                metrics.rttHistory.shift();
+            }
+
+            this.globalRttHistory.push(rtt);
+            if (this.globalRttHistory.length > 2000) {
+                this.globalRttHistory.shift();
+            }
+
+            metrics.lastRtt = rtt;
+            metrics.lastUpdate = Date.now();
+
+            this.determineDeviceState(identifier);
+        }
+
+        this.sendUpdate();
+    }
+
+    private determineDeviceState(identifier: string) {
+        const metrics = this.deviceMetrics.get(identifier);
+        if (!metrics) return;
+
+        if (metrics.state === 'OFFLINE') {
+            if (metrics.lastRtt <= 5000 && metrics.recentRtts.length > 0) {
+                logger.debug(`Device ${identifier} came back online (RTT: ${metrics.lastRtt}ms)`);
+            } else {
+                return;
+            }
+        }
+
+        const movingAvg = metrics.recentRtts.reduce((a, b) => a + b, 0) / metrics.recentRtts.length;
+
+        let median = 0;
+        let threshold = 0;
+
+        if (this.globalRttHistory.length >= 3) {
+            const sorted = [...this.globalRttHistory].sort((a, b) => a - b);
+            const mid = Math.floor(sorted.length / 2);
+            median = sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+            threshold = median * 0.9;
+
+            if (movingAvg < threshold) {
+                metrics.state = 'Online';
+            } else {
+                metrics.state = 'Standby';
+            }
+        } else {
+            metrics.state = 'Calibrating...';
+        }
+
+        const stateColor = metrics.state === 'Online' ? '🟢' : metrics.state === 'Standby' ? '🟡' : '⚪';
+        logger.info(`${stateColor} ${identifier}: ${metrics.state} (RTT: ${metrics.lastRtt}ms, Avg: ${movingAvg.toFixed(0)}ms)`);
+    }
+
+    private sendUpdate() {
+        const devices = Array.from(this.deviceMetrics.entries()).map(([id, metrics]) => ({
+            jid: id,
+            state: metrics.state,
+            rtt: metrics.lastRtt,
+            avg: metrics.recentRtts.length > 0
+                ? metrics.recentRtts.reduce((a, b) => a + b, 0) / metrics.recentRtts.length
+                : 0
+        }));
+
+        const globalMedian = this.calculateGlobalMedian();
+        const globalThreshold = globalMedian * 0.9;
+
+        const data = {
+            devices,
+            deviceCount: 1,
+            presence: null,
+            median: globalMedian,
+            threshold: globalThreshold
+        };
+
+        if (this.onUpdate) {
+            this.onUpdate(data);
+        }
+    }
+
+    private calculateGlobalMedian(): number {
+        if (this.globalRttHistory.length < 3) return 0;
+
+        const sorted = [...this.globalRttHistory].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+
+    /**
+     * Stop tracking and clean up resources
+     */
+    public stopTracking() {
+        this.isTracking = false;
+
+        if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+        }
+
+        if (this.reconnectTimeout) {
+            clearTimeout(this.reconnectTimeout);
+            this.reconnectTimeout = null;
+        }
+
+        // Clean up serialized probe state
+        if (this.pendingProbeTimeout) {
+            clearTimeout(this.pendingProbeTimeout);
+            this.pendingProbeTimeout = null;
+        }
+        this.pendingProbeStartTime = null;
+        if (this.probeResolve) {
+            this.probeResolve();
+            this.probeResolve = null;
+        }
+
+        logger.info('Tracking stopped');
+    }
+}
+
+/**
+ * Check if signal-cli-rest-api is available and get linked accounts
+ */
+export async function getSignalAccounts(apiUrl: string): Promise<string[]> {
+    try {
+        const response = await fetch(`${apiUrl}/v1/accounts`);
+        if (response.ok) {
+            const data = await response.json();
+            return data.map((acc: any) => acc.number || acc);
+        }
+    } catch (err) {
+        console.error('[SIGNAL] Failed to get accounts:', err);
+    }
+    return [];
+}
+
+/**
+ * Get QR code link URL for device linking
+ */
+export function getSignalQrLinkUrl(apiUrl: string, deviceName: string = 'activity-tracker'): string {
+    return `${apiUrl}/v1/qrcodelink?device_name=${encodeURIComponent(deviceName)}`;
+}
+
+/**
+ * Check if a number is registered and discoverable on Signal
+ */
+export async function checkSignalNumber(
+    apiUrl: string,
+    senderNumber: string,
+    targetNumber: string
+): Promise<{ registered: boolean; error?: string }> {
+    try {
+        const response = await fetch(
+            `${apiUrl}/v1/search/${encodeURIComponent(senderNumber)}?numbers=${encodeURIComponent(targetNumber)}`,
+            { signal: AbortSignal.timeout(30000) }
+        );
+
+        if (response.ok) {
+            const results = await response.json();
+            if (Array.isArray(results) && results.length > 0) {
+                const result = results[0];
+                if (result.registered) {
+                    return { registered: true };
+                } else {
+                    return {
+                        registered: false,
+                        error: 'Number is not registered on Signal or has privacy settings blocking discovery'
+                    };
+                }
+            }
+        }
+
+        return { registered: false, error: 'Failed to check Signal registration status' };
+    } catch (err) {
+        return { registered: false, error: `Signal API error: ${err}` };
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Adds Signal tracking alongside existing WhatsApp support
- Uses signal-cli-rest-api in json-rpc mode with WebSocket for delivery receipts
- Serialized probe approach for reliable RTT correlation
- Docker auto-starts with `npm run start:server`
- Platform toggle in web UI

## Test plan
- [x] Signal tracking detects online/standby states via RTT
- [x] Docker container auto-starts in json-rpc mode
- [x] Web UI shows platform selection
- [x] QR code linking works for Signal accounts