### PR TITLE
fix: handle device JIDs in WhatsApp receipt matching

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -334,11 +334,24 @@ export class WhatsAppTracker {
             // We only care about 'inactive' receipts here
             if (attrs.type === 'inactive') {
                 trackerLogger.debug(`[RAW RECEIPT] Received inactive receipt: ${JSON.stringify(attrs)}`);
-                
+
                 const msgId = attrs.id;
                 const fromJid = attrs.from;
-                
-                if (this.trackedJids.has(fromJid)) {
+
+                // Guard against missing from attribute
+                if (!fromJid) {
+                    trackerLogger.debug('[RAW RECEIPT] Missing from JID in receipt');
+                    return;
+                }
+
+                // Extract base number from device JID (e.g., "15109129852:22@s.whatsapp.net" -> "15109129852")
+                const baseNumber = fromJid.split('@')[0].split(':')[0];
+
+                // Check if this matches our target (with or without device ID)
+                const isTracked = this.trackedJids.has(fromJid) ||
+                                  this.trackedJids.has(`${baseNumber}@s.whatsapp.net`);
+
+                if (isTracked) {
                     this.processAck(msgId, fromJid, 'inactive');
                 }
             }


### PR DESCRIPTION
## Summary

Bug accidentally introduced in PR #15: receipts from device JIDs (e.g., `15109129852:22@s.whatsapp.net`) weren't matching `trackedJids` which only contained base JIDs (`15109129852@s.whatsapp.net`), causing all WhatsApp users to show as OFFLINE.

**Fix:**
- Extract base number from device JID and check both formats
- Add null guard for missing `from` attribute to prevent crashes

## Test plan
- [x] Tested WhatsApp tracking with multiple device JIDs
- [x] Verified receipts are correctly matched and RTT calculated
- [x] Confirmed users show correct Online/Standby/Offline states