### PR TITLE
fix: Add Windows support for Docker startup & friendly Docker checks (Ref #20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "tsc",
     "start": "npx tsx src/index.ts",
     "start:server": "npm run start:signal-api && npx tsx src/server.ts",
-    "start:signal-api": "docker start signal-api 2>/dev/null || docker run -d --name signal-api -p 8080:8080 -v $HOME/.local/share/signal-api:/home/.local/share/signal-cli -e MODE=json-rpc bbernhard/signal-cli-rest-api || true",
+    "start:signal-api": "npx tsx src/scripts/init-signal.ts",
     "start:client": "cd client && npm start",
     "dev": "npm run start:server",
     "postinstall": "cd client && npm install"

--- a/src/scripts/init-signal.ts
+++ b/src/scripts/init-signal.ts
@@ -1,0 +1,40 @@
+import { execSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+
+const CONTAINER_NAME = 'signal-api';
+const IMAGE_NAME = 'bbernhard/signal-cli-rest-api';
+const PORT = 8080;
+
+// Cross-platform path to local share
+const hostVolPath = path.join(os.homedir(), '.local', 'share', 'signal-api');
+const containerVolPath = '/home/.local/share/signal-cli';
+
+try {
+  // 1. First, check if Docker is actually running
+  try {
+    execSync('docker info', { stdio: 'ignore' });
+  } catch (e) {
+    console.error('⚠️  Docker is not running.');
+    console.error('   Please start Docker Desktop and try again.');
+    process.exit(1);
+  }
+
+  // 2. Check if container exists using 'docker inspect'
+  try {
+    execSync(`docker inspect ${CONTAINER_NAME}`, { stdio: 'ignore' });
+    console.log(`✅ Container '${CONTAINER_NAME}' found. Starting...`);
+    execSync(`docker start ${CONTAINER_NAME}`, { stdio: 'inherit' });
+  } catch (e) {
+    // 3. If inspect fails, container doesn't exist. Create it.
+    console.log(`🆕 Container '${CONTAINER_NAME}' not found. Creating...`);
+    
+    const cmd = `docker run -d --name ${CONTAINER_NAME} -p ${PORT}:${PORT} -v "${hostVolPath}:${containerVolPath}" -e MODE=json-rpc ${IMAGE_NAME}`;
+    
+    execSync(cmd, { stdio: 'inherit' });
+  }
+} catch (error) {
+  // Catch any other unexpected errors
+  console.error('❌ Failed to initialize Signal API container:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
**Motivation**
Addresses the "Does not run on Windows" issue (Ref #20).

While the log in #20 indicates a dependency issue (`ERR_MODULE_NOT_FOUND`), the current `start:signal-api` script in `package.json` relies on Linux-specific syntax (`$HOME`, `|| true`), which causes the server startup to crash on standard Windows terminals (CMD/PowerShell). 

This PR fixes the Windows startup flow so the project can run successfully.

**Changes**
- Replaced shell-based Docker commands with `src/scripts/init-signal.ts` (TypeScript).
- Implemented cross-platform path handling using `os.homedir()`.
- Added a friendly pre-check for Docker Daemon status.
