### PR TITLE
security: harden Docker images by enforcing non-root user execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ENV PORT=${PORT}
 EXPOSE ${PORT}
 
 # Create directory for WhatsApp auth state
-RUN mkdir -p /app/baileys_auth_info
+RUN mkdir -p /app/baileys_auth_info && chown -R node:node /app
+
+USER node
 
 CMD ["node", "dist/server.js"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -35,6 +35,12 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy built app
 COPY --from=build /app/build /usr/share/nginx/html
 
+# Adjust permissions for nginx user
+RUN touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/run/nginx.pid /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d
+
+USER nginx
+
 # Expose port
 ARG PORT=3000
 ENV PORT=${PORT}


### PR DESCRIPTION
Currently, the application and client containers run as the root user by default. This
  configuration poses a security risk, as any process breakout could lead to full container
  compromise.

  Technical Change:
   - Implemented non-root user execution within Dockerfile (using user node) and client/Dockerfile
     (using user nginx).
   - Adjusted directory permissions to ensure the applications can still operate correctly without
     elevated privileges.
   - Properly handled PID file and cache directories for the Nginx process in the client container.

  Following these Docker security best practices significantly reduces the attack surface and aligns
  with the principle of least privilege.