### PR TITLE
Fix Recharts Tooltip labelFormatter TypeScript typing in ContactCard

### DIFF
--- a/client/src/components/ContactCard.tsx
+++ b/client/src/components/ContactCard.tsx
@@ -186,8 +186,16 @@ export function ContactCard({
                                     <XAxis dataKey="timestamp" hide />
                                     <YAxis domain={['auto', 'auto']} />
                                     <Tooltip
-                                        labelFormatter={(t: number) => new Date(t).toLocaleTimeString()}
-                                        contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
+                                      labelFormatter={(label) => {
+                                        const t = typeof label === "number" ? label : Number(label);
+                                        if (!Number.isFinite(t)) return String(label ?? "");
+                                        return new Date(t).toLocaleTimeString();
+                                      }}
+                                      contentStyle={{
+                                        borderRadius: "8px",
+                                        border: "none",
+                                        boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+                                      }}
                                     />
                                     <Line type="monotone" dataKey="avg" stroke="#3b82f6" strokeWidth={2} dot={false} name="Avg RTT" isAnimationActive={false} />
                                     <Line type="step" dataKey="threshold" stroke="#ef4444" strokeDasharray="5 5" dot={false} name="Threshold" isAnimationActive={false} />


### PR DESCRIPTION
This PR fixes a TypeScript compile error in ContactCard.tsx caused by an incorrect labelFormatter signature passed to Recharts Tooltip. Recharts types the label argument as ReactNode/any (not strictly number), so the callback now accepts label and safely coerces it to a timestamp when possible. If the value can’t be parsed as a valid number, it falls back to a string to avoid runtime issues while keeping the same time formatting behavior.