### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ docker compose down
 #### Web Interface
 
 ```bash
-# Terminal 1: Start backend
+# Terminal 1.1: Start backend (WhatsApp only)
 npm run start:server
+
+# Terminal 1.2: Start backend (WhatsApp + Signal) Docker needed
+npm run start:server:signal
 
 # Terminal 2: Start frontend
 npm run start:client

--- a/client/src/components/ContactCard.tsx
+++ b/client/src/components/ContactCard.tsx
@@ -186,7 +186,7 @@ export function ContactCard({
                                     <XAxis dataKey="timestamp" hide />
                                     <YAxis domain={['auto', 'auto']} />
                                     <Tooltip
-                                        labelFormatter={(t: number) => new Date(t).toLocaleTimeString()}
+                                        labelFormatter={(t: any) => new Date(t).toLocaleTimeString()}
                                         contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
                                     />
                                     <Line type="monotone" dataKey="avg" stroke="#3b82f6" strokeWidth={2} dot={false} name="Avg RTT" isAnimationActive={false} />

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "build": "tsc",
     "start": "npx tsx src/index.ts",
-    "start:server": "npm run start:signal-api && npx tsx src/server.ts",
+    "start:server": "npx tsx src/server.ts",
+    "start:server:signal": "npm run start:signal-api && npx tsx src/server.ts",
     "start:signal-api": "npx tsx src/scripts/init-signal.ts",
     "start:client": "cd client && npm start",
     "dev": "npm run start:server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,21 +14,21 @@ const originalStdoutWrite = process.stdout.write.bind(process.stdout);
 // prevents Baileys from spamming the console
 const shouldSuppressOutput = (message: string): boolean => {
     return message.includes('Closing session:') ||
-           message.includes('SessionEntry') ||
-           message.includes('_chains') ||
-           message.includes('registrationId') ||
-           message.includes('currentRatchet') ||
-           message.includes('ephemeralKeyPair') ||
-           message.includes('pendingPreKey') ||
-           message.includes('indexInfo') ||
-           message.includes('baseKey') ||
-           message.includes('remoteIdentityKey') ||
-           message.includes('lastRemoteEphemeralKey') ||
-           message.includes('previousCounter') ||
-           message.includes('rootKey') ||
-           message.includes('signedKeyId') ||
-           message.includes('preKeyId') ||
-           message.includes('<Buffer');
+        message.includes('SessionEntry') ||
+        message.includes('_chains') ||
+        message.includes('registrationId') ||
+        message.includes('currentRatchet') ||
+        message.includes('ephemeralKeyPair') ||
+        message.includes('pendingPreKey') ||
+        message.includes('indexInfo') ||
+        message.includes('baseKey') ||
+        message.includes('remoteIdentityKey') ||
+        message.includes('lastRemoteEphemeralKey') ||
+        message.includes('previousCounter') ||
+        message.includes('rootKey') ||
+        message.includes('signedKeyId') ||
+        message.includes('preKeyId') ||
+        message.includes('<Buffer');
 };
 
 if (!debugMode) {
@@ -58,7 +58,7 @@ if (!debugMode) {
 
 // Now safe to import modules
 import '@whiskeysockets/baileys';
-import makeWASocket, { DisconnectReason, useMultiFileAuthState } from '@whiskeysockets/baileys';
+import makeWASocket, { DisconnectReason, useMultiFileAuthState, fetchLatestBaileysVersion } from '@whiskeysockets/baileys';
 import { pino } from 'pino';
 import { Boom } from '@hapi/boom';
 import qrcode from 'qrcode-terminal';
@@ -77,11 +77,17 @@ let currentTracker: WhatsAppTracker | null = null;
 
 async function connectToWhatsApp() {
     const { state, saveCreds } = await useMultiFileAuthState('auth_info_baileys');
+    const { version, isLatest } = await fetchLatestBaileysVersion();
+    if (debugMode) {
+        originalConsoleLog(`Using WA v${version.join('.')}, isLatest: ${isLatest}`);
+    }
 
     const sock = makeWASocket({
+        version,
         auth: state,
         logger: pino({ level: 'silent' }),
         markOnlineOnConnect: true,
+        browser: ['Windows', 'Chrome', '120.0.0'],
     });
 
     originalConsoleLog('🔌 Connecting to WhatsApp... (use the --debug flag for more details)');
@@ -103,12 +109,15 @@ async function connectToWhatsApp() {
                 currentTracker = null;
             }
 
-            const shouldReconnect = (lastDisconnect?.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut;
+            const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode;
+            const shouldReconnect = statusCode !== DisconnectReason.loggedOut && statusCode !== 405;
             if (debugMode) {
-                originalConsoleLog('connection closed due to ', lastDisconnect?.error, ', reconnecting ', shouldReconnect);
+                originalConsoleLog(`connection closed due to error (Status: ${statusCode}): `, lastDisconnect?.error, ', reconnecting ', shouldReconnect);
             }
             if (shouldReconnect) {
-                connectToWhatsApp();
+                setTimeout(() => connectToWhatsApp(), 3000);
+            } else {
+                originalConsoleLog('⚠️ Session logged out. Please completely stop the process, delete auth_info_baileys, and restart.');
             }
         } else if (connection === 'open') {
             originalConsoleLog('✅ Connected to WhatsApp');

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
-import makeWASocket, { DisconnectReason, useMultiFileAuthState } from '@whiskeysockets/baileys';
+import makeWASocket, { DisconnectReason, useMultiFileAuthState, fetchLatestBaileysVersion } from '@whiskeysockets/baileys';
 import { pino } from 'pino';
 import { Boom } from '@hapi/boom';
 import { WhatsAppTracker, ProbeMethod } from './tracker.js';
@@ -50,12 +50,16 @@ const trackers: Map<string, TrackerEntry> = new Map(); // JID/Number -> Tracker 
 
 async function connectToWhatsApp() {
     const { state, saveCreds } = await useMultiFileAuthState('auth_info_baileys');
+    const { version, isLatest } = await fetchLatestBaileysVersion();
+    console.log(`Using WA v${version.join('.')}, isLatest: ${isLatest}`);
 
     sock = makeWASocket({
+        version,
         auth: state,
         logger: pino({ level: 'debug' }),
         markOnlineOnConnect: true,
         printQRInTerminal: false,
+        browser: ['Windows', 'Chrome', '120.0.0'],
     });
 
     sock.ev.on('connection.update', async (update: any) => {
@@ -70,10 +74,13 @@ async function connectToWhatsApp() {
         if (connection === 'close') {
             isWhatsAppConnected = false;
             currentWhatsAppQr = null; // Clear QR on close
-            const shouldReconnect = (lastDisconnect?.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut;
-            console.log('connection closed, reconnecting ', shouldReconnect);
+            const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode;
+            const shouldReconnect = statusCode !== DisconnectReason.loggedOut && statusCode !== 405;
+            console.log(`Connection closed (Status: ${statusCode}). Reconnecting: ${shouldReconnect}`);
             if (shouldReconnect) {
-                connectToWhatsApp();
+                setTimeout(() => connectToWhatsApp(), 3000);
+            } else {
+                console.log('⚠️ Session logged out. Please completely stop the server, delete auth_info_baileys, and restart.');
             }
         } else if (connection === 'open') {
             isWhatsAppConnected = true;


### PR DESCRIPTION
### **Problem Description**

**This PR addresses three critical issues that currently prevent the application from running successfully out-of-the-box:**

**1. WhatsApp QR Code Not Generating (405 Forbidden & Infinite Loop)**
When starting the backend or CLI, WhatsApp rejects the connection and returns a `405 Forbidden` error. This happens because the default browser signature (`['DeviceTracker', ...]`) is flagged by WhatsApp's anti-spam systems, and the hardcoded WhatsApp Web version in the Baileys library is outdated. Furthermore, the connection logic treats the 405 error as a temporary drop and attempts to reconnect immediately, causing an infinite loop that prevents the QR code from ever being generated.

**2. Frontend TypeScript Build Error**
When attempting to start the React frontend (`npm run start:client`), the build fails with a `TS2322` error in `src/components/ContactCard.tsx`. The `labelFormatter` property in the Recharts `<Tooltip />` component is strictly typed as `(t: number)`, which conflicts with Recharts' internal expectation of `ReactNode`, breaking the frontend compilation process.

**3. Unnecessary Docker Dependency for WhatsApp-only tracking**
The default `npm run start:server` command is chained with the `start:signal-api` script (`npx tsx src/scripts/init-signal.ts`). This script requires Docker to be running to initialize the Signal API container. If a user only wants to use the WhatsApp tracking feature (which does not require Docker) and doesn't have Docker running, the entire Node.js backend fails to start and crashes.


### Proposed Changes
**Commit: fix(frontend): resolve TS2322 type error in Recharts Tooltip**
- Change parameter type from `number` to `any` in `labelFormatter`
- This fixes the type incompatibility with Recharts' internal `ReactNode` type expectation, allowing the frontend to build successfully.

**Commit: fix(cli): update browser signature, WhatsApp version to fix 405 error and connection loop**
- Update browser signature to mimic Windows/Chrome to bypass anti-spam
- Implement fetchLatestBaileysVersion() to use the most recent WA Web version
- Abort automatic reconnection if the server returns a 405 (Forbidden) status code

**Commit: feat: add separate start scripts for WhatsApp and Signal**
- Updated the Manual Setup section to reflect the new backend start scripts. Clarified the options for starting the server with WhatsApp only (Terminal 1.1) versus WhatsApp + Signal which requires Docker (Terminal 1.2).